### PR TITLE
Update test gen and benchmark for blockwise kr>2

### DIFF
--- a/bench/gemm-benchmark.h
+++ b/bench/gemm-benchmark.h
@@ -397,7 +397,7 @@ void GEMMBenchmark(benchmark::State& state,
 
   const size_t mc = state.range(0);
   const size_t nc = state.range(1);
-  const size_t kc = state.range(2);
+  const size_t kc = round_up_po2(state.range(2), 2 * kr * sr);
   const size_t bl = round_up_po2(state.range(3), 2 * kr * sr);
 
   const size_t nc_stride = benchmark::utils::RoundUp(nc, nr);
@@ -584,7 +584,7 @@ void GEMMBenchmark(benchmark::State& state,
 
   const size_t mc = state.range(0);
   const size_t nc = state.range(1);
-  const size_t kc = state.range(2);
+  const size_t kc = round_up_po2(state.range(2), 2 * kr * sr);
   const size_t bl = round_up_po2(state.range(3), 2 * kr * sr);
 
   const size_t nc_stride = benchmark::utils::RoundUp(nc, nr);

--- a/test/gemm-microkernel-tester.cc
+++ b/test/gemm-microkernel-tester.cc
@@ -50,32 +50,32 @@ TEST_P(GemmTest, Test) {
 
   // Loop over the `k`, `m`, and `n` values, if required.
   for (size_t k = params.loop_k_.from; k <= params.loop_k_.to;
-       k = NextPrime(k + params.loop_k_.step)) {
+       k = params.loop_k_.next(k)) {
     if (params.loop_k_.is_set) {
       tester.k(k);
     }
     for (size_t m = params.loop_m_.from; m <= params.loop_m_.to;
-         m += params.loop_m_.step) {
+         m = params.loop_m_.next(m)) {
       if (params.loop_m_.is_set) {
         tester.m(m);
       }
       for (size_t n = params.loop_n_.from; n <= params.loop_n_.to;
-           n  = NextPrime(n + params.loop_n_.step)) {
+           n = params.loop_n_.next(n)) {
         if (params.loop_n_.is_set) {
           tester.n(n);
         }
         for (size_t zi = params.loop_zi_.from; zi <= params.loop_zi_.to;
-             zi += params.loop_zi_.step) {
+             zi = params.loop_zi_.next(zi)) {
           if (params.loop_zi_.is_set) {
             tester.zero_index(zi);
           }
           for (size_t bzp = params.loop_bzp_.from; bzp <= params.loop_bzp_.to;
-               bzp += params.loop_bzp_.step) {
+               bzp = params.loop_bzp_.next(bzp)) {
             if (params.loop_bzp_.is_set) {
               tester.b_zero_point(bzp);
             }
             for (size_t bl = params.loop_bl_.from; bl <= tester.k() / 2;
-               bl += params.loop_bl_.step) {
+               bl = params.loop_bl_.next(bl)) {
               
                if (params.loop_bl_.is_set) {
                 // Require block size to divide (padded) column size.

--- a/test/gemm-microkernel-tester.h
+++ b/test/gemm-microkernel-tester.h
@@ -32,6 +32,25 @@
 #include <xnnpack/post-operation.h>
 #endif  // XNN_PLATFORM_JIT
 
+inline bool IsPrime(size_t n) {
+    if (n == 1 || n == 2) {
+      return true;
+    }
+    for (size_t k = 3; k * k <= n; k += 2) {
+      if (n % k == 0) {
+        return false;
+      }
+    }
+    return true;
+}
+
+inline size_t NextPrime(size_t n) {
+    n = (n + 1) | static_cast<size_t>(1);
+    while (!IsPrime(n)) {
+      n++;
+    }
+    return n;
+}
 
 class GemmMicrokernelTester {
  public:
@@ -491,14 +510,29 @@ class GemmMicrokernelTester {
   bool relu_{false};
 };
 
+enum class LoopStepType {
+  Linear,
+  NextPrime
+};
+
 struct LoopParams {
   LoopParams() = default;
-  explicit LoopParams(size_t from, size_t to, size_t step)
-      : is_set(true), from(from), to(to), step(step) {}
+  explicit LoopParams(size_t from, size_t to, size_t step, LoopStepType step_type)
+      : is_set(true), from(from), to(to), step(step), step_type(step_type) {}
   bool is_set = false;
   size_t from = 1;
   size_t to = 1;
   size_t step = 1;
+  LoopStepType step_type = LoopStepType::Linear;
+
+  size_t next(size_t n) const {
+    switch (step_type) {
+      case LoopStepType::Linear:
+        return n + step;
+      case LoopStepType::NextPrime:
+        return NextPrime(n + step);
+    }
+  }
 };
 
 struct GemmTestParams {
@@ -511,28 +545,28 @@ struct GemmTestParams {
         isa_check(isa_check) {}
 
   // Setters for the loops over `k`, `m`, and `n`.
-  GemmTestParams& loop_k(size_t from, size_t to, size_t step = 1) {
-    loop_k_ = LoopParams(from, to, step);
+  GemmTestParams& loop_k(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::NextPrime) {
+    loop_k_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_m(size_t from, size_t to, size_t step = 1) {
-    loop_m_ = LoopParams(from, to, step);
+  GemmTestParams& loop_m(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_m_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_n(size_t from, size_t to, size_t step = 1) {
-    loop_n_ = LoopParams(from, to, step);
+  GemmTestParams& loop_n(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::NextPrime) {
+    loop_n_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_zi(size_t from, size_t to, size_t step = 1) {
-    loop_zi_ = LoopParams(from, to, step);
+  GemmTestParams& loop_zi(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_zi_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_bzp(size_t from, size_t to, size_t step = 1) {
-    loop_bzp_ = LoopParams(from, to, step);
+  GemmTestParams& loop_bzp(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_bzp_ = LoopParams(from, to, step, step_type);
     return *this;
   }
-  GemmTestParams& loop_bl(size_t from, size_t to, size_t step = 1) {
-    loop_bl_ = LoopParams(from, to, step);
+  GemmTestParams& loop_bl(size_t from, size_t to, size_t step = 1, LoopStepType step_type = LoopStepType::Linear) {
+    loop_bl_ = LoopParams(from, to, step, step_type);
     return *this;
   }
 
@@ -549,23 +583,3 @@ struct GemmTestParams {
 };
 
 using GemmTest = testing::TestWithParam<GemmTestParams>;
-
-inline bool IsPrime(size_t n) {
-    if (n == 1 || n == 2) {
-      return true;
-    }
-    for (size_t k = 3; k * k <= n; k += 2) {
-      if (n % k == 0) {
-        return false;
-      }
-    }
-    return true;
-}
-
-inline size_t NextPrime(size_t n) {
-    n = (n + 1) | static_cast<size_t>(1);
-    while (!IsPrime(n)) {
-      n++;
-    }
-    return n;
-}

--- a/tools/generate-gemm-test.py
+++ b/tools/generate-gemm-test.py
@@ -236,36 +236,79 @@ std::vector<GemmTestParams> CreateTests(
         , test_func, isa_check)
         .loop_n(1, nr)
         .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs,
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1));
-    if (!is_igemm) {
+  $if KERNELTYPE not in ['qb4w']:
+    if (k_block > 1) {
       gemm_tests.push_back(GemmTestParams(
-          "k_lt_" + akbs + "_strided_a",
+          "k_lt_" + akbs,
           GemmMicrokernelTester()
               $if EXTENDED_WEIGHTS:
                 .extended_weights(true)
               .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-              .a_stride(NextPrime(adj_k_block + 1))
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
                 .bl(kr * sr * 2)
           , test_func, isa_check)
           .loop_k(1, adj_k_block - 1));
+      if (!is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "k_lt_" + akbs + "_strided_a",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                .a_stride(NextPrime(adj_k_block + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(1, adj_k_block - 1));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "k_lt_" + akbs + "_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, adj_k_block - 1)
+          .loop_n(1, nr)
+          .loop_m(1, mr));
     }
     gemm_tests.push_back(GemmTestParams(
-        "k_lt_" + akbs + "_subtile",
+        "k_gt_" + akbs,
+        GemmMicrokernelTester()
+            $if EXTENDED_WEIGHTS:
+              .extended_weights(true)
+            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+            $if KERNELTYPE in ['qb4w', 'qc4w']:
+              .b_zero_point(8)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+        , test_func, isa_check)
+        .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
+    if (is_igemm) {
+      gemm_tests.push_back(GemmTestParams(
+          "k_gt_" + akbs + "_strided_a",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+              .a_stride(NextPrime(adj_k_block * 2 + 1))
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+        , test_func, isa_check)
+        .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
+    }
+    gemm_tests.push_back(GemmTestParams(
+        "k_gt_" + akbs + "_subtile",
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
@@ -275,81 +318,136 @@ std::vector<GemmTestParams> CreateTests(
             $if KERNELTYPE in ['qb4w']:
               .bl(kr * sr * 2)
         , test_func, isa_check)
-        .loop_k(1, adj_k_block - 1)
+        .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
         .loop_n(1, nr)
         .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  if (is_igemm) {
+    if (k_block > 1) {
+      gemm_tests.push_back(GemmTestParams(
+          "k_div_" + kbs,
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(adj_k_block + k_block, k_block * 5, k_block));
+      if (is_igemm) {
+        gemm_tests.push_back(GemmTestParams(
+            "k_div_" + kbs + "_strided_a",
+            GemmMicrokernelTester()
+                $if EXTENDED_WEIGHTS:
+                  .extended_weights(true)
+                .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+                .a_stride(NextPrime(k_block * 3 + 1))
+                $if KERNELTYPE in ['qb4w', 'qc4w']:
+                  .b_zero_point(8)
+                $if KERNELTYPE in ['qb4w']:
+                  .bl(kr * sr * 2)
+            , test_func, isa_check)
+            .loop_k(adj_k_block + k_block, k_block * 3, k_block));
+      }
+      gemm_tests.push_back(GemmTestParams(
+          "k_div_" + kbs + "_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(adj_k_block + k_block, k_block * 5, k_block)
+          .loop_n(1, nr)
+          .loop_m(1, mr));
+    }
     gemm_tests.push_back(GemmTestParams(
-        "k_gt_" + akbs + "_strided_a",
+        "n_gt_" + nrs,
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_stride(NextPrime(adj_k_block * 2 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "k_gt_" + akbs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(adj_k_block + 1, adj_k_block * 2 - 1, k_block)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (k_block > 1) {
-    gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs,
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
               .bl(kr * sr * 2)
         , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block));
-    if (is_igemm) {
+        $if NR_SCALE != "":
+          .loop_n(nr + 1, nr * 2 - 1, 4)
+        $else:
+          .loop_n(nr + 1, nr * 2 - 1)
+        .loop_k(1, k_block * 3, k_block + 1));
+    $if JIT:
       gemm_tests.push_back(GemmTestParams(
-          "k_div_" + kbs + "_strided_a",
+          "unknown_nc_mod_nr",
           GemmMicrokernelTester()
               $if EXTENDED_WEIGHTS:
                 .extended_weights(true)
-              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).known_nc_mod_nr(false)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          $if NR_SCALE != "":
+            .loop_n(1, nr * 2 - 1, 4)
+          $else:
+            .loop_n(1, nr * 2 - 1)
+          .loop_k(1, k_block * 3, k_block + 1));
+      gemm_tests.push_back(GemmTestParams(
+          "relu",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).relu(true)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check));
+    gemm_tests.push_back(GemmTestParams(
+        "n_gt_" + nrs + "_strided_cn",
+        GemmMicrokernelTester()
+            $if EXTENDED_WEIGHTS:
+              .extended_weights(true)
+            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+            .cn_stride(NextPrime(nr + 1))
+            $if KERNELTYPE in ['qb4w', 'qc4w']:
+              .b_zero_point(8)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+        , test_func, isa_check)
+        $if NR_SCALE != "":
+          .loop_n(nr + 1, nr * 2 - 1, 4)
+        $else:
+          .loop_n(nr + 1, nr * 2 - 1)
+        .loop_k(1, k_block * 3, k_block + 1));
+    if (!is_igemm) {
+      gemm_tests.push_back(GemmTestParams(
+          "n_gt_" + nrs + "_strided_a",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
               .a_stride(NextPrime(k_block * 3 + 1))
               $if KERNELTYPE in ['qb4w', 'qc4w']:
                 .b_zero_point(8)
               $if KERNELTYPE in ['qb4w']:
                 .bl(kr * sr * 2)
           , test_func, isa_check)
-          .loop_k(adj_k_block + k_block, k_block * 3, k_block));
+          $if NR_SCALE != "":
+            .loop_n(nr + 1, nr * 2 - 1, 4)
+          $else:
+            .loop_n(nr + 1, nr * 2 - 1)
+          .loop_k(1, k_block * 3, k_block));
     }
     gemm_tests.push_back(GemmTestParams(
-        "k_div_" + kbs + "_subtile",
+        "n_gt_" + nrs + "_subtile",
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
@@ -359,185 +457,134 @@ std::vector<GemmTestParams> CreateTests(
             $if KERNELTYPE in ['qb4w']:
               .bl(kr * sr * 2)
         , test_func, isa_check)
-        .loop_k(adj_k_block + k_block, k_block * 5, k_block)
-        .loop_n(1, nr)
-        .loop_m(1, mr));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      $if NR_SCALE != "":
-        .loop_n(nr + 1, nr * 2 - 1, 4)
-      $else:
-        .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  $if JIT:
-    gemm_tests.push_back(GemmTestParams(
-        "unknown_nc_mod_nr",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).known_nc_mod_nr(false)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "relu",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).relu(true)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      $if NR_SCALE != "":
-        .loop_n(nr + 1, nr * 2 - 1, 4)
-      $else:
-        .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_strided_a",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
         $if NR_SCALE != "":
           .loop_n(nr + 1, nr * 2 - 1, 4)
         $else:
           .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_gt_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      $if NR_SCALE != "":
-        .loop_n(nr + 1, nr * 2 - 1, 4)
-      $else:
-        .loop_n(nr + 1, nr * 2 - 1)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs,
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_strided_cn",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-          .cn_stride(NextPrime(nr + 1))
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1));
-  if (!is_igemm) {
+        .loop_k(1, k_block * 3, k_block + 1)
+        .loop_m(1, mr));
     gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_strided_a",
+        "n_div_" + nrs,
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
             .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
-            .a_stride(NextPrime(k_block * 3 + 1))
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
               .bl(kr * sr * 2)
         , test_func, isa_check)
         .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "n_div_" + nrs + "_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_n(nr * 2, nr * 3, nr)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_m(1, mr));
-  if (is_igemm) {
+        .loop_k(1, k_block * 3, k_block + 1));
     gemm_tests.push_back(GemmTestParams(
-        "small_kernel",
+        "n_div_" + nrs + "_strided_cn",
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+            .cn_stride(NextPrime(nr + 1))
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
               .bl(kr * sr * 2)
         , test_func, isa_check)
+        .loop_n(nr * 2, nr * 3, nr)
         .loop_k(1, k_block * 3, k_block + 1));
+    if (!is_igemm) {
+      gemm_tests.push_back(GemmTestParams(
+          "n_div_" + nrs + "_strided_a",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr)
+              .a_stride(NextPrime(k_block * 3 + 1))
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_n(nr * 2, nr * 3, nr)
+          .loop_k(1, k_block * 3, k_block));
+    }
     gemm_tests.push_back(GemmTestParams(
-        "small_kernel_subtile",
+        "n_div_" + nrs + "_subtile",
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
+            .mr(mr).nr(nr).kr(kr).sr(sr).iterations(1)
+            $if KERNELTYPE in ['qb4w', 'qc4w']:
+              .b_zero_point(8)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+        , test_func, isa_check)
+        .loop_n(nr * 2, nr * 3, nr)
+        .loop_k(1, k_block * 3, k_block + 1)
+        .loop_m(1, mr));
+    if (is_igemm) {
+      gemm_tests.push_back(GemmTestParams(
+          "small_kernel",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1));
+      gemm_tests.push_back(GemmTestParams(
+          "small_kernel_subtile",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).ks(3).iterations(1)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1)
+          .loop_n(1, nr)
+          .loop_m(1, mr));
+      gemm_tests.push_back(GemmTestParams(
+          "n_gt_" + nrs + "_small_kernel",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          $if NR_SCALE != "":
+            .loop_n(nr + 1, nr * 2 - 1, 4)
+          $else:
+            .loop_n(nr + 1, nr * 2 - 1)
+          .loop_k(1, k_block * 3, k_block + 1));
+      gemm_tests.push_back(GemmTestParams(
+          "n_div_" + nrs + "_small_kernel",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_n(nr * 2, nr * 3, nr)
+          .loop_k(1, k_block * 3, k_block + 1));
+    }
+    gemm_tests.push_back(GemmTestParams(
+        "strided_cm_subtile",
+        GemmMicrokernelTester()
+            $if EXTENDED_WEIGHTS:
+              .extended_weights(true)
+            .mr(mr).nr(nr).kr(kr).sr(sr)
+            .cm_stride(NextPrime(nr + 1))
+            .iterations(1)
             $if KERNELTYPE in ['qb4w', 'qc4w']:
               .b_zero_point(8)
             $if KERNELTYPE in ['qb4w']:
@@ -546,152 +593,107 @@ std::vector<GemmTestParams> CreateTests(
         .loop_k(1, k_block * 3, k_block + 1)
         .loop_n(1, nr)
         .loop_m(1, mr));
+    if (is_igemm) {
+      gemm_tests.push_back(GemmTestParams(
+          "a_offset",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+              .a_offset(NextPrime(mr * k_block * 3 + 1))
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1));
+      gemm_tests.push_back(GemmTestParams(
+          "zero",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
+              .a_offset(NextPrime(mr * k_block * 3 + 1))
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1)
+          .loop_zi(0, mr - 1));
+    }
+    $if ACTIVATION == "MINMAX":
+      gemm_tests.push_back(GemmTestParams(
+          "qmin",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check));
+      gemm_tests.push_back(GemmTestParams(
+          "qmax",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
+              $if KERNELTYPE in ['qb4w', 'qc4w']:
+                .b_zero_point(8)
+              $if KERNELTYPE in ['qb4w']:
+                .bl(kr * sr * 2)
+          , test_func, isa_check));
     gemm_tests.push_back(GemmTestParams(
-        "n_gt_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        $if NR_SCALE != "":
-          .loop_n(nr + 1, nr * 2 - 1, 4)
-        $else:
-          .loop_n(nr + 1, nr * 2 - 1)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "n_div_" + nrs + "_small_kernel",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).ks(3)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_n(nr * 2, nr * 3, nr)
-        .loop_k(1, k_block * 3, k_block + 1));
-  }
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm_subtile",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr)
-          .cm_stride(NextPrime(nr + 1))
-          .iterations(1)
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check)
-      .loop_k(1, k_block * 3, k_block + 1)
-      .loop_n(1, nr)
-      .loop_m(1, mr));
-  if (is_igemm) {
-    gemm_tests.push_back(GemmTestParams(
-        "a_offset",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "zero",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).ks(3)
-            .a_offset(NextPrime(mr * k_block * 3 + 1))
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1)
-        .loop_zi(0, mr - 1));
-  }
-  $if ACTIVATION == "MINMAX":
-    gemm_tests.push_back(GemmTestParams(
-        "qmin",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmin(128)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-    gemm_tests.push_back(GemmTestParams(
-        "qmax",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block).qmax(128)
-            $if KERNELTYPE in ['qb4w', 'qc4w']:
-              .b_zero_point(8)
-            $if KERNELTYPE in ['qb4w']:
-              .bl(kr * sr * 2)
-        , test_func, isa_check));
-  gemm_tests.push_back(GemmTestParams(
-      "strided_cm",
-      GemmMicrokernelTester()
-          $if EXTENDED_WEIGHTS:
-            .extended_weights(true)
-          .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-          .cm_stride(NextPrime(nr + 1))
-          $if KERNELTYPE in ['qb4w', 'qc4w']:
-            .b_zero_point(8)
-          $if KERNELTYPE in ['qb4w']:
-            .bl(kr * sr * 2)
-      , test_func, isa_check));
-  $if DATATYPE == "qu8":
-    gemm_tests.push_back(GemmTestParams(
-        "no_a_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).a_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-  $if DATATYPE == "qu8":
-    gemm_tests.push_back(GemmTestParams(
-        "no_b_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).b_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
-    gemm_tests.push_back(GemmTestParams(
-        "b_zero_point",
+        "strided_cm",
         GemmMicrokernelTester()
             $if EXTENDED_WEIGHTS:
               .extended_weights(true)
             .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
-        , test_func, isa_check)
-        .loop_bzp(0, 255));
-    gemm_tests.push_back(GemmTestParams(
-        "no_zero_point",
-        GemmMicrokernelTester()
-            $if EXTENDED_WEIGHTS:
-              .extended_weights(true)
-            .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
-            .a_zero_point(0)
-            .b_zero_point(0)
-        , test_func, isa_check)
-        .loop_k(1, k_block * 3, k_block + 1));
+            .cm_stride(NextPrime(nr + 1))
+            $if KERNELTYPE in ['qb4w', 'qc4w']:
+              .b_zero_point(8)
+            $if KERNELTYPE in ['qb4w']:
+              .bl(kr * sr * 2)
+        , test_func, isa_check));
+    $if DATATYPE == "qu8":
+      gemm_tests.push_back(GemmTestParams(
+          "no_a_zero_point",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).a_zero_point(0)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1));
+    $if DATATYPE == "qu8":
+      gemm_tests.push_back(GemmTestParams(
+          "no_b_zero_point",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).b_zero_point(0)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1));
+      gemm_tests.push_back(GemmTestParams(
+          "b_zero_point",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block)
+          , test_func, isa_check)
+          .loop_bzp(0, 255));
+      gemm_tests.push_back(GemmTestParams(
+          "no_zero_point",
+          GemmMicrokernelTester()
+              $if EXTENDED_WEIGHTS:
+                .extended_weights(true)
+              .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr)
+              .a_zero_point(0)
+              .b_zero_point(0)
+          , test_func, isa_check)
+          .loop_k(1, k_block * 3, k_block + 1));
+          
   $if KERNELTYPE in ['qb4w']:
     gemm_tests.push_back(GemmTestParams(
         "bl",
@@ -701,7 +703,7 @@ std::vector<GemmTestParams> CreateTests(
             .mr(mr).nr(nr).kr(kr).sr(sr).m(mr).n(nr).k(k_block * 12)
             .b_zero_point(8)
         , test_func, isa_check)
-        .loop_k(k_block, k_block * 12, k_block)
+        .loop_k(k_block, k_block * 12, k_block, LoopStepType::Linear)
         .loop_bl(2 * kr * sr, k_block * 12, 2 * kr * sr));
 
   return gemm_tests;


### PR DESCRIPTION
Update test generation and benchmark logic for qb4w kernels to respect blockwise constraints - specifically that blocksize must be a multiple of 2*kr*sr and than kc must be a multiple of blocksize.

For test coverage, effectively all of the kt_lt and kt_gt tests are incompatible with this assumption. In effect, they can be all considered edge cases, but blockwise kernels don't really support any of these edge cases. As such, they aren't really applicable. The bl test, which linearly steps both bl and k by 2*kr*sr should provide sufficient coverage.

For benchmarking, I also round bl and kc up to a multiple of 2 * kr * sr. This does happen in the benchmark runner, so it is not reflected in the displayed benchmark case parameters. I arguably could put the logic in the benchmark wrapper, so this is the case. Could go either way.